### PR TITLE
fix: syntax error in  pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,4 @@ websockets = "11.0.3"
 python-dotenv = "^1.0.0"
 TTS = "0.22.0"
 pydantic = "^2.8.2"
-instructor == "1.3.7"
-
+instructor = "1.3.7"


### PR DESCRIPTION
There's a syntax issue in the pyproject.toml file where the dependency for the instructor package was incorrectly specified using `==`, shouldn't it be `=`